### PR TITLE
Feature/logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/loophole/cli/internal/app/loophole"
 	lm "github.com/loophole/cli/internal/app/loophole/models"
+	"github.com/mattn/go-colorable"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -65,7 +66,7 @@ func init() {
 }
 
 func initLogger() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: colorable.NewColorableStderr()})
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if verbose {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,16 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	stdlog "log"
 	"os"
-	"regexp"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/loophole/cli/internal/app/loophole"
@@ -72,69 +67,20 @@ func init() {
 }
 
 func initLogger() {
-	logLocation := "logs/" + time.Now().Format("2006-01-02--15-04-05") + ".log" //path to where the current log file will be saved at, named after the timestamp of its creation for now
+	logLocation := "logs/" + time.Now().Format("2006-01-02--15-04-05") + ".log"
 
-	var err error
-
-	if _, err := os.Stat("logs"); err != nil { //does the logs folder exist? If not, create it
+	if _, err := os.Stat("logs"); err != nil {
 		os.Mkdir("logs", 0700)
 	}
 
-	r, w, err := os.Pipe() //create a pipe that leads everything written into the writer back into the reader
+	f, err := os.Create(logLocation)
 	if err != nil {
-		stdlog.Fatalf("Error creating pipe:" + err.Error())
+		stdlog.Fatalln("Error creating log file:", err)
 	}
+	consoleWriter := zerolog.ConsoleWriter{Out: colorable.NewColorableStderr()}
+	multi := zerolog.MultiLevelWriter(consoleWriter, f)
+	log.Logger = zerolog.New(multi).With().Timestamp().Logger()
 
-	go func(r *os.File) {
-		var logMutex sync.Mutex //Mutex to prevent simultaneous read and write access to the log string
-
-		buf := new(bytes.Buffer) //Buffer that will hold the unedited logs
-		logstring := ""          //the log string that will be written into a file
-
-		go func(buf *bytes.Buffer, r *os.File) { //Continuously read all logs into the Buffer
-			for {
-				time.Sleep(500 * time.Millisecond)
-				_, err = io.Copy(buf, r)
-				if err != nil {
-					stdlog.Fatalf("Error creating log buffer: %v", err)
-				}
-			}
-		}(buf, r)
-
-		go func(logstring *string, logMutex *sync.Mutex) { //Continuously save an ANSI stripped version of those logs into a string
-			for {
-				time.Sleep(500 * time.Millisecond)
-				exp := regexp.MustCompile("\\[\\d+m")
-				exp2 := regexp.MustCompile("")
-				logMutex.Lock()
-				*logstring = exp2.ReplaceAllString((exp.ReplaceAllString(buf.String(), "")), "") //remove all occurrences of both regexes from the logs
-				logMutex.Unlock()
-			}
-		}(&logstring, &logMutex)
-
-		go func(logstring *string, logMutex *sync.Mutex) { //Continuously save that string into a file
-			for {
-				var logFile []byte //declaring the variable that will hold the data of the currently existing log file
-				time.Sleep(500 * time.Millisecond)
-
-				if _, err := os.Stat(logLocation); err == nil {
-					logFile, _ = ioutil.ReadFile(logLocation)
-				}
-				logMutex.Lock()
-				if !bytes.Equal([]byte(*logstring), logFile) { //check if there is something new to write to the logfile
-
-					err := ioutil.WriteFile(logLocation, []byte(*logstring), 0777)
-					if err != nil {
-						fmt.Println(err)
-					}
-				}
-				logMutex.Unlock()
-			}
-		}(&logstring, &logMutex)
-	}(r)
-
-	wrt := io.MultiWriter(colorable.NewColorableStderr(), w) // create a multiwriter that writes all it receives into both the ColorableStderr as well as the writer of the pipe
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: wrt}) // set the multiwriter to be the output of our logs
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if verbose {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-acme/lego/v3 v3.7.0
 	github.com/kyokomi/emoji v2.2.4+incompatible
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
+	github.com/mattn/go-colorable v0.1.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rs/zerolog v1.19.0
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -21,6 +21,7 @@ import (
 	lm "github.com/loophole/cli/internal/app/loophole/models"
 	"github.com/loophole/cli/internal/pkg/cache"
 	"github.com/loophole/cli/internal/pkg/token"
+	"github.com/mattn/go-colorable"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/crypto/ssh"
@@ -37,6 +38,8 @@ var remoteEndpoint = lm.Endpoint{
 	Port: 80,
 }
 
+var colorableOutput = colorable.NewColorableStdout()
+
 func parsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
 	key, err := ioutil.ReadFile(file)
 
@@ -49,7 +52,7 @@ func parsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
 
 	if err != nil {
 		if errors.As(err, &passwordError) {
-			fmt.Print("Enter SSH password:")
+			fmt.Fprint(colorableOutput, "Enter SSH password:")
 			password, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 			signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(password))
 			if err != nil {
@@ -157,8 +160,8 @@ func registerSite(apiURL string, publicKey ssh.PublicKey, siteID string) (string
 }
 
 func printWelcomeMessage() {
-	fmt.Print(aurora.Cyan("Loophole"))
-	fmt.Print(aurora.Italic(" - End to end TLS encrypted TCP communication between you and your clients"))
+	fmt.Fprint(colorableOutput, aurora.Cyan("Loophole"))
+	fmt.Fprint(colorableOutput, aurora.Italic(" - End to end TLS encrypted TCP communication between you and your clients"))
 	fmt.Println()
 	fmt.Println()
 }
@@ -322,15 +325,15 @@ func generateListener(config lm.Config, publicKeyAuthMethod *ssh.AuthMethod, pub
 	}
 
 	fmt.Println()
-	fmt.Print("Forwarding ")
-	fmt.Print(aurora.Green(fmt.Sprintf("http://%s.loophole.site", siteID)))
-	fmt.Print(" -> ")
-	fmt.Print(aurora.Green(fmt.Sprintf("%s:%d", config.Host, config.Port)))
+	fmt.Fprint(colorableOutput, "Forwarding ")
+	fmt.Fprint(colorableOutput, aurora.Green(fmt.Sprintf("http://%s.loophole.site", siteID)))
+	fmt.Fprint(colorableOutput, " -> ")
+	fmt.Fprint(colorableOutput, aurora.Green(fmt.Sprintf("%s:%d", config.Host, config.Port)))
 	fmt.Println()
-	fmt.Print("Forwarding ")
-	fmt.Print(aurora.Green(fmt.Sprintf("https://%s.loophole.site", siteID)))
-	fmt.Print(" -> ")
-	fmt.Print(aurora.Green(fmt.Sprintf("%s:%d", config.Host, config.Port)))
+	fmt.Fprint(colorableOutput, "Forwarding ")
+	fmt.Fprint(colorableOutput, aurora.Green(fmt.Sprintf("https://%s.loophole.site", siteID)))
+	fmt.Fprint(colorableOutput, " -> ")
+	fmt.Fprint(colorableOutput, aurora.Green(fmt.Sprintf("%s:%d", config.Host, config.Port)))
 	fmt.Println()
 	fmt.Println()
 	emoji.Println(fmt.Sprintf(":nerd: %s", aurora.Italic("TLS Certificate will be obtained with first request to the above address, therefore first execution may be slower")))

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -180,8 +180,6 @@ func loadingSuccess(loader *spinner.Spinner) {
 	if el := log.Debug(); !el.Enabled() {
 		loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Green(":check_mark:"))
 		loader.Stop()
-	} else {
-		fmt.Println(emoji.Sprint(loader.Prefix))
 	}
 }
 
@@ -189,8 +187,6 @@ func loadingFailure(loader *spinner.Spinner) {
 	if el := log.Debug(); !el.Enabled() {
 		loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Red(":cross_mark:"))
 		loader.Stop()
-	} else {
-		fmt.Fprintln(colorableOutput, emoji.Sprint(loader.Prefix))
 	}
 }
 

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -183,7 +183,7 @@ func loadingFailure(loader *spinner.Spinner) {
 
 func generateListener(config lm.Config, publicKeyAuthMethod *ssh.AuthMethod, publicKey *ssh.PublicKey) (net.Listener, *lm.Endpoint) {
 
-	loader := spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+	loader := spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithWriter(colorable.NewColorableStdout()))
 
 	localEndpoint := lm.Endpoint{
 		Host: config.Host,
@@ -240,7 +240,7 @@ func generateListener(config lm.Config, publicKeyAuthMethod *ssh.AuthMethod, pub
 
 	if el := log.Debug(); el.Enabled() {
 		fmt.Println()
-		el.Msg("Dialing gatway to estabilish the tunnel..")
+		el.Msg("Dialing gateway to establish the tunnel..")
 	}
 	serverSSHConnHTTPS, err := ssh.Dial("tcp", config.GatewayEndpoint.String(), sshConfigHTTPS)
 	if err != nil {
@@ -336,8 +336,8 @@ func generateListener(config lm.Config, publicKeyAuthMethod *ssh.AuthMethod, pub
 	fmt.Fprint(colorableOutput, aurora.Green(fmt.Sprintf("%s:%d", config.Host, config.Port)))
 	fmt.Println()
 	fmt.Println()
-	emoji.Println(fmt.Sprintf(":nerd: %s", aurora.Italic("TLS Certificate will be obtained with first request to the above address, therefore first execution may be slower")))
-	emoji.Println(":newspaper: Logs:")
+	fmt.Fprint(colorableOutput, emoji.Sprint(fmt.Sprintf(":nerd: %s", aurora.Italic("TLS Certificate will be obtained with first request to the above address, therefore first execution may be slower\n"))))
+	fmt.Fprint(colorableOutput, emoji.Sprint(":newspaper: Logs:\n"))
 
 	log.Info().Msg("Awaiting connections...")
 	return listenerHTTPSOverSSH, proxiedEndpointHTTPS

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -54,6 +54,7 @@ func parsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
 		if errors.As(err, &passwordError) {
 			fmt.Fprint(colorableOutput, "Enter SSH password:")
 			password, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Println()
 			signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(password))
 			if err != nil {
 				return nil, nil, err
@@ -167,18 +168,30 @@ func printWelcomeMessage() {
 }
 
 func startLoading(loader *spinner.Spinner, message string) {
-	loader.Prefix = emoji.Sprintf("%s ", message)
-	loader.Start()
+	if el := log.Debug(); !el.Enabled() {
+		loader.Prefix = emoji.Sprintf("%s ", message)
+		loader.Start()
+	} else {
+		fmt.Println(emoji.Sprint(message))
+	}
 }
 
 func loadingSuccess(loader *spinner.Spinner) {
-	loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Green(":check_mark:"))
-	loader.Stop()
+	if el := log.Debug(); !el.Enabled() {
+		loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Green(":check_mark:"))
+		loader.Stop()
+	} else {
+		fmt.Println(emoji.Sprint(loader.Prefix))
+	}
 }
 
 func loadingFailure(loader *spinner.Spinner) {
-	loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Red(":cross_mark:"))
-	loader.Stop()
+	if el := log.Debug(); !el.Enabled() {
+		loader.FinalMSG = emoji.Sprintf("%s%s\n", loader.Prefix, aurora.Red(":cross_mark:"))
+		loader.Stop()
+	} else {
+		fmt.Fprintln(colorableOutput, emoji.Sprint(loader.Prefix))
+	}
 }
 
 func generateListener(config lm.Config, publicKeyAuthMethod *ssh.AuthMethod, publicKey *ssh.PublicKey) (net.Listener, *lm.Endpoint) {


### PR DESCRIPTION
Closes #12

(Not sending them yet, only writing logs to file)

A working, but in hindsight very crude logging feature.

I used a multiwriter to write the logs simultaneously to the console as well as a buffer. 
Then using goroutines I continuously write the string from the buffer (minus the ANSI escape codes that would make the logs unreadable) into a string. 
In another goroutine I write that ANSI stripped log string into a logfile after checking if the current logfile is up to date or not.


After talking a little bit with Max on Tuesday, I realized that we could just wrap our calls to the logger in a function that always also appends the clean strings to a logfile instead of doing it in a roundabout way like I did here.

Is the second approach I described okay or should we do it in a completely different way? Would like some input before rewriting it @Morishiri 