### PR TITLE
Move closehandler to pkg, move feedback form to closehandler

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -43,6 +43,9 @@ To expose port running on some local host e.g. 192.168.1.20 use 'loophole http <
 		}
 		return nil
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return parseBasicAuthFlags(cmd.Flags())
+	},
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,8 +29,6 @@ var rootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initLogger)
 
-	displayOptions.FeedbackFormURL = "https://forms.gle/K9ga7FZB3deaffnV7"
-
 	rootCmd.PersistentFlags().BoolVarP(&displayOptions.Verbose, "verbose", "v", false, "verbose output")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	lm "github.com/loophole/cli/internal/app/loophole/models"
 	"github.com/loophole/cli/internal/pkg/cache"
+	"github.com/loophole/cli/internal/pkg/closehandler"
 	"github.com/mattn/go-colorable"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -29,6 +30,8 @@ var rootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initLogger)
 
+	displayOptions.FeedbackFormURL = "https://forms.gle/K9ga7FZB3deaffnV7"
+	closehandler.SetupCloseHandler(displayOptions.FeedbackFormURL)
 	rootCmd.PersistentFlags().BoolVarP(&displayOptions.Verbose, "verbose", "v", false, "verbose output")
 }
 

--- a/cmd/virtual-serve.go
+++ b/cmd/virtual-serve.go
@@ -6,6 +6,7 @@ import (
 
 	lm "github.com/loophole/cli/internal/app/loophole/models"
 	"github.com/loophole/cli/internal/pkg/cache"
+	"github.com/loophole/cli/internal/pkg/closehandler"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
@@ -35,6 +36,7 @@ func initServeCommand(serveCmd *cobra.Command) {
 }
 
 func parseBasicAuthFlags(flagset *pflag.FlagSet) error {
+	closehandler.SetupCloseHandler()
 	usernameProvided := false
 	passwordProvided := false
 	var passwordFlag *pflag.Flag

--- a/cmd/virtual-serve.go
+++ b/cmd/virtual-serve.go
@@ -52,7 +52,7 @@ func parseBasicAuthFlags(flagset *pflag.FlagSet) error {
 	})
 
 	if usernameProvided && !passwordProvided {
-		fmt.Print("Enter basic auth password:")
+		fmt.Print("Enter basic auth password: ")
 
 		password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {

--- a/cmd/virtual-serve.go
+++ b/cmd/virtual-serve.go
@@ -6,7 +6,6 @@ import (
 
 	lm "github.com/loophole/cli/internal/app/loophole/models"
 	"github.com/loophole/cli/internal/pkg/cache"
-	"github.com/loophole/cli/internal/pkg/closehandler"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
@@ -36,7 +35,6 @@ func initServeCommand(serveCmd *cobra.Command) {
 }
 
 func parseBasicAuthFlags(flagset *pflag.FlagSet) error {
-	closehandler.SetupCloseHandler()
 	usernameProvided := false
 	passwordProvided := false
 	var passwordFlag *pflag.Flag

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -273,7 +273,6 @@ func ForwardDirectory(config lm.ExposeDirectoryConfig) {
 
 // ForwardDirectoryViaWebdav is used to expose local directory via Webdav (upload and download)
 func ForwardDirectoryViaWebdav(config lm.ExposeWebdavConfig) {
-	closehandler.SetupCloseHandler()
 	communication.PrintWelcomeMessage()
 
 	publicKeyAuthMethod, publicKey := parsePublicKey(config.Remote.IdentityFile)

--- a/internal/app/loophole/loophole.go
+++ b/internal/app/loophole/loophole.go
@@ -242,7 +242,6 @@ func listenOnRemoteEndpoint(serverSSHConnHTTPS *ssh.Client) net.Listener {
 
 // ForwardPort is used to forward external URL to locally available port
 func ForwardPort(config lm.ExposeHttpConfig) {
-	closehandler.SetupCloseHandler()
 	communication.PrintWelcomeMessage()
 
 	protocol := "http"
@@ -263,7 +262,6 @@ func ForwardPort(config lm.ExposeHttpConfig) {
 
 // ForwardDirectory is used to expose local directory via HTTP (download only)
 func ForwardDirectory(config lm.ExposeDirectoryConfig) {
-	closehandler.SetupCloseHandler()
 	communication.PrintWelcomeMessage()
 
 	publicKeyAuthMethod, publicKey := parsePublicKey(config.Remote.IdentityFile)

--- a/internal/app/loophole/models/DisplayOptions.go
+++ b/internal/app/loophole/models/DisplayOptions.go
@@ -2,6 +2,7 @@ package models
 
 // DisplayOptions represents configuration used to display certain things in CLI
 type DisplayOptions struct {
-	Verbose bool
-	QR      bool
+	Verbose         bool
+	QR              bool
+	FeedbackFormURL string
 }

--- a/internal/app/loophole/models/DisplayOptions.go
+++ b/internal/app/loophole/models/DisplayOptions.go
@@ -2,7 +2,6 @@ package models
 
 // DisplayOptions represents configuration used to display certain things in CLI
 type DisplayOptions struct {
-	Verbose         bool
-	QR              bool
-	FeedbackFormURL string
+	Verbose bool
+	QR      bool
 }

--- a/internal/pkg/closehandler/closehandler.go
+++ b/internal/pkg/closehandler/closehandler.go
@@ -13,11 +13,8 @@ import (
 var successfulConnectionOccured bool = false
 var terminalState *terminal.State = &terminal.State{}
 
-//FeedbackFormURL contains the link to the feedbackform
-var FeedbackFormURL string = "https://forms.gle/K9ga7FZB3deaffnV7"
-
 //SetupCloseHandler ensures that CTRL+C inputs are properly processed, restoring the terminal state from not displaying entered characters where necessary
-func SetupCloseHandler() {
+func SetupCloseHandler(feedbackFormURL string) {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	terminalState, err := terminal.GetState(int(os.Stdin.Fd()))
@@ -32,7 +29,7 @@ func SetupCloseHandler() {
 		}
 		communication.PrintGoodbyeMessage()
 		if successfulConnectionOccured {
-			communication.PrintFeedbackMessage(FeedbackFormURL)
+			communication.PrintFeedbackMessage(feedbackFormURL)
 		}
 		os.Exit(0)
 	}()

--- a/internal/pkg/closehandler/closehandler.go
+++ b/internal/pkg/closehandler/closehandler.go
@@ -1,0 +1,44 @@
+package closehandler
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/loophole/cli/internal/pkg/communication"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var successfulConnectionOccured bool = false
+var terminalState *terminal.State = &terminal.State{}
+
+//FeedbackFormURL contains the link to the feedbackform
+var FeedbackFormURL string = "https://forms.gle/K9ga7FZB3deaffnV7"
+
+//SetupCloseHandler ensures that CTRL+C inputs are properly processed, restoring the terminal state from not displaying entered characters where necessary
+func SetupCloseHandler() {
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	terminalState, err := terminal.GetState(int(os.Stdin.Fd()))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error saving terminal state")
+	}
+
+	go func() {
+		<-c
+		if terminalState != nil {
+			terminal.Restore(int(os.Stdin.Fd()), terminalState)
+		}
+		communication.PrintGoodbyeMessage()
+		if successfulConnectionOccured {
+			communication.PrintFeedbackMessage(FeedbackFormURL)
+		}
+		os.Exit(0)
+	}()
+}
+
+//SuccessfulConnectionOccured sets the corresponding boolean to true, enabling the display of the feedback form URL after closing the CLI
+func SuccessfulConnectionOccured() {
+	successfulConnectionOccured = true
+}

--- a/internal/pkg/keys/keys.go
+++ b/internal/pkg/keys/keys.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/loophole/cli/internal/pkg/closehandler"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
@@ -19,7 +18,6 @@ import (
 
 //ParsePublicKey retrieves an ssh.AuthMethod and the related PublicKey
 func ParsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
-	closehandler.SetupCloseHandler()
 	privateKey, err := ioutil.ReadFile(file)
 
 	var pathError *os.PathError

--- a/internal/pkg/keys/keys.go
+++ b/internal/pkg/keys/keys.go
@@ -55,7 +55,7 @@ func ParsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
 
 			signer, err = getSignerFromSSHAgent(publicKey)
 			if err != nil {
-				fmt.Print("Enter SSH password:")
+				fmt.Print("Enter SSH password: ")
 
 				password, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 				fmt.Println()

--- a/internal/pkg/keys/keys.go
+++ b/internal/pkg/keys/keys.go
@@ -11,13 +11,15 @@ import (
 	"net"
 	"os"
 
+	"github.com/loophole/cli/internal/pkg/closehandler"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
 //ParsePublicKey retrieves an ssh.AuthMethod and the related PublicKey
-func ParsePublicKey(terminalState *terminal.State, file string) (ssh.AuthMethod, ssh.PublicKey, error) {
+func ParsePublicKey(file string) (ssh.AuthMethod, ssh.PublicKey, error) {
+	closehandler.SetupCloseHandler()
 	privateKey, err := ioutil.ReadFile(file)
 
 	var pathError *os.PathError
@@ -56,11 +58,6 @@ func ParsePublicKey(terminalState *terminal.State, file string) (ssh.AuthMethod,
 			signer, err = getSignerFromSSHAgent(publicKey)
 			if err != nil {
 				fmt.Print("Enter SSH password:")
-				terminalState, err = terminal.GetState(int(os.Stdin.Fd()))
-				if err != nil {
-					return nil, nil, err
-				}
-				terminalState = nil
 
 				password, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 				fmt.Println()


### PR DESCRIPTION
Closes #71 

There is still a bug where several instances of "Goodbye" will be printed at the end because a separate closehandler seems to be needed for every pkg inside of which the user might press CTRL+C; a way of closing the closehandler without closing the program is the next step