### PR TITLE
Fix build instructions in readme after #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ $ go test -v ./...
 ### Running
 
 ```
-# go run main.go
+# go run cli.go
 ```
 
 ### Building
 
 ```
-# go build -o loophole main.go
+# go build -o loophole cli.go
 ```


### PR DESCRIPTION
https://github.com/loophole/cli/pull/84/commits/a3efe7452c807419ed262154066a8f44eab99c3e renamed main.go → cli.go